### PR TITLE
Fix crash

### DIFF
--- a/parser.y
+++ b/parser.y
@@ -13,7 +13,7 @@ int yyerror(state*, char const*);
 
 %pure-parser
 %parse-param {state *s}
-%lex-param {void *scanner}
+%lex-param {YYLEX_PARAM}
 
 %union {
   node *node;

--- a/test/test.sh
+++ b/test/test.sh
@@ -2,7 +2,7 @@
 bin=$(dirname $0)/../minivm
 ret=0
 for f in $(dirname $0)/*/*.in; do
-  output=$($bin < $f)
+  output=$($bin < $f | sed "s/\n//g")
   expected=$(cat ${f%.in}.out)
   if [[ X$output != X$expected ]]; then
     echo Test failed!


### PR DESCRIPTION
* yylex に正しく scanner が渡っていなくて落ちていたのを修正しました。
* Windows だと改行コードを取らないと比較が失敗するのを修正しました。